### PR TITLE
Add DSL for artifact definitions

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -129,21 +129,21 @@ Note that this operation doesn't require any Element data to be pre-set.  It wil
 
 The "update" operation is similar to "create" in that Element data is already expected to be defined for this operation:
 
-user_object.add_method(:name => "update") {
-  db = SQLite3::Database.open "users.db"
-  sql_string = "Update users SET first_name=\'"
-  sql_string << @first_name.to_s
-  sql_string << "\', last_name=\'"
-  sql_string << @last_name.to_s
-  sql_string << "\', username=\'"
-  sql_string << @username.to_s
-  sql_string << "\' WHERE id="
-  sql_string << @id.to_s
-  sql_string << ";"
-  Vidalia.log("Updating user ID=#{@id} with DB call \"#{sql_string}\"")
-  db.execute sql_string
-  db.close
-}
+  user_object.add_method(:name => "update") {
+    db = SQLite3::Database.open "users.db"
+    sql_string = "Update users SET first_name=\'"
+    sql_string << @first_name.to_s
+    sql_string << "\', last_name=\'"
+    sql_string << @last_name.to_s
+    sql_string << "\', username=\'"
+    sql_string << @username.to_s
+    sql_string << "\' WHERE id="
+    sql_string << @id.to_s
+    sql_string << ";"
+    Vidalia.log("Updating user ID=#{@id} with DB call \"#{sql_string}\"")
+    db.execute sql_string
+    db.close
+  }
 
 And "delete" requires just an Element or two to accomplish its goal:
 
@@ -203,12 +203,57 @@ We need three more Elements to complete our example:
 
 And now our Object declaration is complete!  Now on to the workflow layer.
 
+=== Defining Interface, Objects, and Elements using the DSL
+
+Alternatively, the Vidalia DSL can be used to define an interface, its objects, and each object's elements. The intent of the DSL is to provide a cleaner way to define Vidalia artifacts by minimizing boilerplate code and eliminiating the need to store definitions in variables and pass them to descendants. Here is how the previous examples can be re-written using the DSL:
+
+  interface 'Application DB' do
+
+    object 'User' do
+      init do
+        singleton_class.class_eval { attr_accessor :id  }
+        @id = nil
+        singleton_class.class_eval { attr_accessor :first_name  }
+        @first_name = nil
+        singleton_class.class_eval { attr_accessor :last_name  }
+        @last_name = nil
+        singleton_class.class_eval { attr_accessor :username  }
+        @username = nil
+      end
+
+      create do
+        singleton_class.class_eval { attr_accessor :id }
+        @id = nil
+        singleton_class.class_eval { attr_accessor :first_name }
+        @first_name = nil
+        singleton_class.class_eval { attr_accessor :last_name }
+        @last_name = nil
+        singleton_class.class_eval { attr_accessor :username }
+        @username = nil
+      end
+
+      read { ... }
+      update { ... }
+      delete { ... }
+
+      element 'ID' do
+        get { |opts| @parent.id }
+        set { |value| @@parent.id = value }
+      end
+
+      element 'First Name' { ... }
+      element 'Last Name' { ... }
+      element 'Username' { ... }
+    end
+  end
+
+
 === Invoke the Workflow
 
 To define the workflow layer, let's edit +demo.rb+.  First we need to require Vidalia:
 
   require 'vidalia'
-  
+
 Next we want to load our object definition.
 
   require './page'

--- a/lib/vidalia.rb
+++ b/lib/vidalia.rb
@@ -5,6 +5,7 @@ require 'vidalia/artifact'
 require 'vidalia/interface'
 require 'vidalia/object'
 require 'vidalia/element'
+require 'vidalia/dsl'
 
 # [cat]  something
 # something else

--- a/lib/vidalia/dsl.rb
+++ b/lib/vidalia/dsl.rb
@@ -1,0 +1,66 @@
+def interface(name, &block)
+  inter_def = Vidalia::InterfaceDefinition.new(name: name)
+  inter_def.instance_eval &block if block
+
+  # object and element will return Vidalia::Object and Vidalia::Element objects,
+  # respectively. Returning a Vidalia::Interface object makes sense here for
+  # consistency
+  inter_def.interface
+end
+
+module Vidalia
+  class Interface
+    attr_accessor :init_block
+  end
+
+  class Object
+    attr_accessor :init_block
+  end
+
+  class Element
+    attr_accessor :init_block
+  end
+
+  class InterfaceDefinition
+    # Set's the interface's init block
+    def init(&block)
+      @interface.init_block = block
+    end
+
+    def object(name, &block)
+      obj_def = Vidalia::ObjectDefinition.new(name: name, parent: self)
+      obj_def.instance_eval &block if block
+      obj_def.object
+    end
+  end
+
+  class ObjectDefinition
+    def init(&block)
+      @object.init_block = block
+    end
+
+    def method_missing(meth_id, &block)
+      @object.add_method(name: meth_id.to_s, &block)
+      # TODO: Honestly not sure why I need this and why add_method doesn't
+      # take care of it
+      Vidalia::Object.define_method_for_object_class meth_id.to_s
+    end
+
+    def element(name, &block)
+      elem_def = Vidalia::ElementDefinition.new(name: name, parent: self)
+      elem_def.instance_eval &block if block
+      elem_def.element
+    end
+  end
+
+  class ElementDefinition
+    def init(&block)
+      @element.init_block = block
+    end
+
+    def method_missing(meth_id, &block)
+      method("add_#{meth_id}".to_sym).call(&block)
+    end
+
+  end
+end

--- a/test/test_element_dsl.rb
+++ b/test/test_element_dsl.rb
@@ -1,0 +1,403 @@
+require 'minitest/autorun'
+require 'test_helper'
+
+class ElementTest < Minitest::Test
+
+  def setup
+    # Clean up the Interface Definitions
+    Vidalia::InterfaceDefinition.reset
+    Vidalia::set_logroutine { |logstring|
+      logstring #No need to print anything out here
+    }
+  end
+
+  def test_element_definition_happy_path_dsl
+    $var = "X"
+    i = o = e = nil
+    i = interface 'i' do
+      o = object 'o' do
+        e = element 'e' do
+          init { $var = 'E' }
+        end
+      end
+    end
+    assert e.is_a?(Vidalia::Element)
+    assert o.number_of_children == 1
+    assert o.get_child("e") == e
+    assert $var == "X"
+  end
+
+  def test_element_instantiation_no_block_dsl
+    $var = "X"
+    interface 'i' do
+      init { $var = "I" }
+      object 'o' do
+        init { $var = "O" }
+        element 'e'
+      end
+    end
+    int = Vidalia::Interface.get("i")
+    assert $var == "I"
+    obj = int.object("o")
+    assert $var == "O"
+    ele = obj.element("e")
+    assert $var == "O"
+  end
+
+  def test_element_get_definition_happy_path_dsl
+    interface 'i' do
+      object 'o' do
+        element 'e1' do
+          get { |instring| instring }
+        end
+        element 'e2' do
+          get { |inhash| inhash[:b] }
+        end
+        element 'e3' do
+          get { |do_not_care| "zebra" }
+        end
+        element 'e4' do
+          get { "Egypt" }
+        end
+      end
+    end
+
+    int = Vidalia::Interface.get("i")
+    obj = int.object("o")
+    ele1 = obj.element("e1")
+    ele2 = obj.element("e2")
+    ele3 = obj.element("e3")
+    ele4 = obj.element("e4")
+    assert ele1.get("hi") == "hi"
+    assert ele2.get({:a => "A",:b => "B",:c => "C"}) == "B"
+    assert ele3.get() == "zebra"
+    assert ele4.get() == "Egypt"
+  end
+
+  def test_element_get_definition_parameter_checking_dsl
+    assert_raises(RuntimeError) do
+      interface 'i' do
+        object 'o' do
+          e1 = element 'e1' do
+            init { $var = 'E1' }
+            # Will raise an error because up to one value can be passed to the
+            # get
+            get { |string1,string2,string3| "#{string1}#{string2}#{string3}" }
+          end
+        end
+      end
+    end
+  end
+
+  def test_element_set_definition_happy_path_dsl
+    $var = "X"
+    interface 'i' do
+      object 'o' do
+        element 'e1' do
+          set { |instring| $var = instring }
+        end
+        element 'e2' do
+          set { |inhash| $var = inhash[:b] }
+        end
+        element 'e3' do
+          set { |do_not_care| $var = "zebra" }
+        end
+        element 'e4' do
+          set { $var = "Egypt" }
+        end
+      end
+    end
+
+    int = Vidalia::Interface.get("i")
+    obj = int.object("o")
+    ele1 = obj.element("e1")
+    ele2 = obj.element("e2")
+    ele3 = obj.element("e3")
+    ele4 = obj.element("e4")
+    $var = "X"
+    ele1.set("hi")
+    assert $var == "hi"
+    ele2.set({:a => "A",:b => "B",:c => "C"})
+    assert $var == "B"
+    ele3.set()
+    assert $var == "zebra"
+    ele4.set()
+    assert $var == "Egypt"
+  end
+
+  def test_element_set_definition_parameter_checking_dsl
+    assert_raises(RuntimeError) do
+      interface 'i' do
+        object 'o' do
+          e1 = element 'e1' do
+            init { $var = 'E1' }
+            # Will raise an error because up to one value can be passed to the
+            # set
+            set { |string1,string2,string3| "#{string1}#{string2}#{string3}" }
+          end
+        end
+      end
+    end
+  end
+
+  def test_element_retrieve_definition_happy_path_dsl
+    $var = "X"
+
+    interface 'i' do
+      object 'o' do
+        element 'e1' do
+          retrieve { |instring| $var = instring }
+        end
+        element 'e2' do
+          retrieve { |inhash| $var = inhash[:b] }
+        end
+        element 'e3' do
+          retrieve { |do_not_care| $var = "zebra" }
+        end
+        element 'e4' do
+          retrieve { $var = "Egypt" }
+        end
+      end
+    end
+
+    int = Vidalia::Interface.get("i")
+    obj = int.object("o")
+    ele1 = obj.element("e1")
+    ele2 = obj.element("e2")
+    ele3 = obj.element("e3")
+    ele4 = obj.element("e4")
+    $var = "X"
+    ele1.retrieve("hi")
+    assert $var == "hi"
+    ele2.retrieve({:a => "A",:b => "B",:c => "C"})
+    assert $var == "B"
+    ele3.retrieve()
+    assert $var == "zebra"
+    ele4.retrieve()
+    assert $var == "Egypt"
+  end
+
+  def test_element_retrieve_definition_parameter_checking_dsl
+    assert_raises(RuntimeError) do
+      interface 'i' do
+        object 'o' do
+          element 'e1' do
+            retrieve { |string1,string2,string3| "#{string1}#{string2}#{string3}" }
+          end
+        end
+      end
+    end
+  end
+
+  def test_element_verify_definition_happy_path_dsl
+    $var = "X"
+
+    interface 'i' do
+      object 'o' do
+        element 'e1' do
+          verify { |instring| $var = instring }
+        end
+        element 'e2' do
+          verify { |inhash| $var = inhash[:b] }
+        end
+        element 'e3' do
+          verify { |do_not_care| $var = "zebra" }
+        end
+        element 'e4' do
+          verify { $var = "Egypt" }
+        end
+      end
+    end
+
+    int = Vidalia::Interface.get("i")
+    obj = int.object("o")
+    ele1 = obj.element("e1")
+    ele2 = obj.element("e2")
+    ele3 = obj.element("e3")
+    ele4 = obj.element("e4")
+    $var = "X"
+    ele1.verify("hi")
+    assert $var == "hi"
+    ele2.verify({:a => "A",:b => "B",:c => "C"})
+    assert $var == "B"
+    ele3.verify()
+    assert $var == "zebra"
+    ele4.verify()
+    assert $var == "Egypt"
+  end
+
+  def test_element_verify_definition_parameter_checking_dsl
+    assert_raises(RuntimeError) do
+      interface 'i' do
+        object 'o' do
+          element 'e1' do
+            verify { |string1,string2,string3| "#{string1}#{string2}#{string3}" }
+          end
+        end
+      end
+    end
+  end
+
+  def test_element_confirm_definition_happy_path_dsl
+    $var = "X"
+
+    interface 'i' do
+      object 'o' do
+        element 'e1' do
+          confirm { |instring| $var = instring }
+        end
+        element 'e2' do
+          confirm { |inhash| $var = inhash[:b] }
+        end
+        element 'e3' do
+          confirm { |do_not_care| $var = "zebra" }
+        end
+        element 'e4' do
+          confirm { $var = "Egypt" }
+        end
+      end
+    end
+
+    int = Vidalia::Interface.get("i")
+    obj = int.object("o")
+    ele1 = obj.element("e1")
+    ele2 = obj.element("e2")
+    ele3 = obj.element("e3")
+    ele4 = obj.element("e4")
+    $var = "X"
+    ele1.confirm("hi")
+    assert $var == "hi"
+    ele2.confirm({:a => "A",:b => "B",:c => "C"})
+    assert $var == "B"
+    ele3.confirm()
+    assert $var == "zebra"
+    ele4.confirm()
+    assert $var == "Egypt"
+  end
+
+  def test_element_confirm_definition_parameter_checking_dsl
+    interface 'i' do
+      object 'o' do
+        element 'e1' do
+          confirm { |instring| $var = instring }
+        end
+        element 'e2' do
+          confirm { |inhash| $var = inhash[:b] }
+        end
+        element 'e3' do
+          confirm { |do_not_care| $var = "zebra" }
+        end
+        element 'e4' do
+          confirm { $var = "Egypt" }
+        end
+      end
+    end
+  end
+  def test_element_update_definition_happy_path_dsl
+    $var = "X"
+
+    interface 'i' do
+      object 'o' do
+        element 'e1' do
+          update { |instring| $var = instring }
+        end
+        element 'e2' do
+          update { |inhash| $var = inhash[:b] }
+        end
+        element 'e3' do
+          update { |do_not_care| $var = "zebra" }
+        end
+        element 'e4' do
+          update { $var = "Egypt" }
+        end
+      end
+    end
+
+    int = Vidalia::Interface.get("i")
+    obj = int.object("o")
+    ele1 = obj.element("e1")
+    ele2 = obj.element("e2")
+    ele3 = obj.element("e3")
+    ele4 = obj.element("e4")
+    $var = "X"
+    ele1.update("hi")
+    assert $var == "hi"
+    ele2.update({:a => "A",:b => "B",:c => "C"})
+    assert $var == "B"
+    ele3.update()
+    assert $var == "zebra"
+    ele4.update()
+    assert $var == "Egypt"
+  end
+
+  def test_element_update_definition_parameter_checking_dsl
+    interface 'i' do
+      object 'o' do
+        element 'e1' do
+          update { |instring| $var = instring }
+        end
+        element 'e2' do
+          update { |inhash| $var = inhash[:b] }
+        end
+        element 'e3' do
+          update { |do_not_care| $var = "zebra" }
+        end
+        element 'e4' do
+          update { $var = "Egypt" }
+        end
+      end
+    end
+  end
+
+  def test_element_generic_get_only_dsl
+    $var = "X"
+
+    interface 'i' do
+      object 'o' do
+        element 'e1' do
+          init { $var = 'E1' }
+          get { $var }
+        end
+      end
+    end
+
+    int = Vidalia::Interface.get("i")
+    obj = int.object("o")
+    ele1 = obj.element("e1")
+    $var = 1
+    assert ele1.get("foo") == 1
+    $var = 2
+    assert ele1.retrieve("foo") == 2
+    $var = 3
+    assert ele1.confirm(3)
+    $var = 4
+    ele1.verify(4)
+  end
+
+  def test_element_generic_get_and_set_dsl
+    $var = "X"
+
+    interface 'i' do
+      object 'o' do
+        element 'e1' do
+          init { $var = 'E1' }
+          get { $var }
+          set { |value| $var = value }
+        end
+      end
+    end
+
+    int = Vidalia::Interface.get("i")
+    obj = int.object("o")
+    ele1 = obj.element("e1")
+    ele1.set(1)
+    assert ele1.get("foo") == 1
+    ele1.update(2)
+    assert ele1.retrieve("foo") == 2
+    ele1.set(3)
+    assert ele1.confirm(3)
+    ele1.update(4)
+    ele1.verify(4)
+  end
+
+end

--- a/test/test_interface_dsl.rb
+++ b/test/test_interface_dsl.rb
@@ -1,0 +1,111 @@
+require 'minitest/autorun'
+require 'test_helper'
+
+class InterfaceTest < Minitest::Test
+
+  def setup
+    # Clean up the Interface Definitions
+    Vidalia::InterfaceDefinition.reset
+    Vidalia::set_logroutine { |logstring|
+      logstring #No need to print anything out here
+    }
+  end
+
+  def test_interface_definition_happy_path_dsl
+    $var = "cat"
+    a = interface 'm' do
+      init { $var = 'dog' }
+    end
+    assert a.is_a?(Vidalia::Interface)
+    assert $var == "cat"
+  end
+
+  def test_interface_definition_parameter_checking_dsl
+    assert_raises(RuntimeError) do
+      interface 2 do
+        init { |var| var = 'dog' }
+      end
+    end
+    assert_raises(ArgumentError) do
+      interface do
+        init { |var| var = 'dog' }
+      end
+    end
+  end
+
+  def test_interface_instantiation_no_block_dsl
+    $var = "X"
+    interface 'i'
+    int = Vidalia::Interface.get("i")
+    assert $var == "X"
+  end
+
+  def test_interface_child_creation_dsl
+    $var = "a"
+
+    interface 'i' do
+      init { $var = 'I' }
+      object 'o1' do
+        init { $var = 'O1' }
+      end
+      object 'o2' do
+        init { $var = 'O2' }
+      end
+      object 'o3' do
+        init { $var = 'O3' }
+      end
+    end
+
+    int = Vidalia::Interface.get("i")
+    assert int.is_a?(Vidalia::Interface)
+    assert $var == "I"
+    assert int.name == "i"
+    assert int.parent == nil
+    assert int.number_of_children == 0
+
+    obj1 = int.object("o1")
+    assert obj1.is_a?(Vidalia::Object)
+    assert $var == "O1"
+    assert obj1.name == "o1"
+    assert obj1.parent == int
+    assert int.number_of_children == 1
+    assert obj1.number_of_children == 0
+
+    obj2 = int.object("o2")
+    assert obj2.is_a?(Vidalia::Object)
+    assert $var == "O2"
+    assert obj2.name == "o2"
+    assert obj2.parent == int
+    assert int.number_of_children == 2
+    assert obj2.number_of_children == 0
+
+    obj3 = int.object("o3")
+    assert obj3.is_a?(Vidalia::Object)
+    assert $var == "O3"
+    assert obj3.name == "o3"
+    assert obj3.parent == int
+    assert int.number_of_children == 3
+    assert obj3.number_of_children == 0
+  end
+
+  def test_multiple_interface_definition_dsl
+    interface 'i' do
+      object 'o1' do
+        init { $var = 'O1' }
+      end
+      object 'o2' do
+        init { $var = 'O2' }
+      end
+    end
+
+    int = Vidalia::Interface.get("i")
+    obj1 = int.object("o1")
+    assert obj1.is_a?(Vidalia::Object)
+    assert obj1.name == "o1"
+
+    obj2 = int.object("o2")
+    assert obj2.is_a?(Vidalia::Object)
+    assert obj2.name == "o2"
+  end
+
+end

--- a/test/test_object_dsl.rb
+++ b/test/test_object_dsl.rb
@@ -1,0 +1,140 @@
+require 'minitest/autorun'
+require 'test_helper'
+
+class ObjectTest < Minitest::Test
+
+  def setup
+    # Clean up the Interface Definitions
+    Vidalia::InterfaceDefinition.reset
+    Vidalia::set_logroutine { |logstring|
+      logstring #No need to print anything out here
+    }
+  end
+
+  def test_object_definition_happy_path_dsl
+    $var = "X"
+
+    o = nil
+    i = interface 'i' do
+      init { $var = 'I' }
+      o = object 'o' do
+        init { $var = 'O' }
+      end
+    end
+    assert o.is_a?(Vidalia::Object)
+    assert i.number_of_children == 1
+    assert i.get_child("o") == o
+    assert $var == "X"
+  end
+
+  def test_object_instantiation_no_block_dsl
+    $var = "X"
+    interface 'i' do
+      init { $var = 'I' }
+      object 'o'
+    end
+    int = Vidalia::Interface.get("i")
+    assert $var == "I"
+    obj = int.object("o")
+    assert $var == "I"
+  end
+
+  def test_object_child_creation_dsl
+    $var = "a"
+
+    interface 'i' do
+      init { $var = "I" }
+      object 'o' do
+        init { $var = 'O' }
+        element 'e1' do
+          init { $var = 'E1' }
+        end
+        element 'e2' do
+          init { $var = 'E2' }
+        end
+        element 'e3' do
+          init { $var = 'E3' }
+        end
+      end
+    end
+
+    int = Vidalia::Interface.get("i")
+    assert int.is_a?(Vidalia::Interface)
+    assert $var == "I"
+    assert int.name == "i"
+    assert int.parent == nil
+    assert int.number_of_children == 0
+
+    obj = int.object("o")
+    assert obj.is_a?(Vidalia::Object)
+    assert $var == "O"
+    assert obj.name == "o"
+    assert obj.parent == int
+    assert int.number_of_children == 1
+    assert obj.number_of_children == 0
+
+
+    ele1 = obj.element("e1")
+    assert ele1.is_a?(Vidalia::Element)
+    assert $var == "E1"
+    assert ele1.name == "e1"
+    assert ele1.parent == obj
+    assert int.number_of_children == 1
+    assert obj.number_of_children == 1
+    assert ele1.number_of_children == 0
+
+    ele2 = obj.element("e2")
+    assert ele2.is_a?(Vidalia::Element)
+    assert $var == "E2"
+    assert ele2.name == "e2"
+    assert ele2.parent == obj
+    assert int.number_of_children == 1
+    assert obj.number_of_children == 2
+    assert ele2.number_of_children == 0
+
+    ele3 = obj.element("e3")
+    assert ele3.is_a?(Vidalia::Element)
+    assert $var == "E3"
+    assert ele3.name == "e3"
+    assert ele3.parent == obj
+    assert int.number_of_children == 1
+    assert obj.number_of_children == 3
+    assert ele3.number_of_children == 0
+  end
+
+  def test_object_add_method_dsl
+    $var = "a"
+
+    interface 'i' do
+      init { $var = 'I' }
+
+      object 'o1' do
+        init { $var = 'O1' }
+        dog { $var = 'dog' }
+        cat { $var = 'cat' }
+      end
+
+      object 'o2' do
+        init { $var = 'O2' }
+        bat { $var = 'bat' }
+      end
+    end
+
+    int = Vidalia::Interface.get("i")
+    obj1 = int.object("o1")
+    obj2 = int.object("o2")
+    assert $var == "O2"
+    obj1.dog
+    assert $var == "dog"
+    obj1.cat
+    assert $var == "cat"
+    assert_raises(RuntimeError) { obj1.bat }
+    assert $var == "cat"
+    obj2.bat
+    assert $var == "bat"
+    assert_raises(RuntimeError) { obj2.cat }
+    assert_raises(RuntimeError) { obj2.dog }
+    assert $var == "bat"
+  end
+
+end

--- a/vidalia.gemspec
+++ b/vidalia.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name        = 'vidalia'
-  s.version     = '0.0.2'
-  s.date        = '2017-04-25'
+  s.version     = '0.1.0'
+  s.date        = '2018-04-20'
   s.summary     = 'Vidalia'
   s.description = 'Vidalia uses layers to simplify the creation and maintenance of API and database calls in your automated test suite.'
   s.add_development_dependency 'minitest', '~> 0'
@@ -14,7 +14,8 @@ Gem::Specification.new do |s|
                    'lib/vidalia/artifact.rb',
                    'lib/vidalia/interface.rb',
                    'lib/vidalia/object.rb',
-                   'lib/vidalia/element.rb']
+                   'lib/vidalia/element.rb',
+                   'lib/vidalia/dsl.rb']
   s.homepage    = 'https://github.com/jrotter/vidalia'
   s.license     = 'MIT'
 end


### PR DESCRIPTION
Created a domain-specific language as an alternate way of defining
Vidalia interfaces, objects, and elements. This has been implement on
top of Vidalia's existing code base to preserve backwards compatibility.

Updated README with an example that re-implements the current example
interface definiton with the DSL.

Unit tests added are copied from the `test/test_interface.rb`,
`test/test_object.rb`, and `test/test_interface.rb` files. The only
difference is the definitions are built using the DSL instead.